### PR TITLE
Add date to CLI command filenames

### DIFF
--- a/cli/commands/analyzer.py
+++ b/cli/commands/analyzer.py
@@ -10,6 +10,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 import pandas as pd
+from datetime import datetime
 
 try:
     from fpat.firewall_analyzer import (
@@ -153,7 +154,8 @@ def redundancy(
             
             # 결과 저장
             if not output_file:
-                output_file = f"redundancy_analysis_{vendor}.xlsx"
+                today = datetime.now().strftime("%Y-%m-%d")
+                output_file = f"{today}_redundancy_analysis_{vendor}.xlsx"
             
             output_path = Path(config.get_output_dir()) / output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
@@ -233,7 +235,8 @@ def shadow(
             
             # 결과 저장
             if not output_file:
-                output_file = f"shadow_analysis_{vendor}.xlsx"
+                today = datetime.now().strftime("%Y-%m-%d")
+                output_file = f"{today}_shadow_analysis_{vendor}.xlsx"
             
             output_path = Path(config.get_output_dir()) / output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
@@ -338,8 +341,9 @@ def filter(
             
             # 결과 저장
             if not output_file:
+                today = datetime.now().strftime("%Y-%m-%d")
                 safe_address = search_address.replace('/', '_').replace('-', '_')
-                output_file = f"filtered_policies_{search_type}_{safe_address}.xlsx"
+                output_file = f"{today}_filtered_policies_{search_type}_{safe_address}.xlsx"
             
             output_path = Path(config.get_output_dir()) / output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
@@ -370,22 +374,38 @@ def show_analysis_summary(results: dict, output_path: Path, analysis_type: str):
     table.add_column("카테고리", style="bold yellow")
     table.add_column("항목 수", style="green")
     
+    has_data = False
     for sheet_name, data in results.items():
         if isinstance(data, pd.DataFrame):
             table.add_row(sheet_name, str(len(data)))
+            if len(data) > 0:
+                has_data = True
         elif isinstance(data, (list, dict)):
             table.add_row(sheet_name, str(len(data)))
+            if len(data) > 0:
+                has_data = True
     
     console.print(table)
     
-    # 성공 메시지
-    success_panel = Panel(
-        f"[green]✅ {analysis_type}이 완료되었습니다![/green]\n\n"
-        f"[bold]저장 위치:[/bold] {output_path}",
-        title="🎉 분석 완료",
-        border_style="green"
-    )
-    console.print(success_panel)
+    # 분석 결과가 없는 경우 메시지 표시
+    if not has_data:
+        no_result_panel = Panel(
+            f"[yellow]ℹ️ {analysis_type} 결과가 없습니다.[/yellow]\n\n"
+            f"[bold]저장 위치:[/bold] {output_path}\n"
+            f"[dim]분석 조건에 맞는 정책이 발견되지 않았습니다.[/dim]",
+            title="📋 분석 결과",
+            border_style="yellow"
+        )
+        console.print(no_result_panel)
+    else:
+        # 성공 메시지
+        success_panel = Panel(
+            f"[green]✅ {analysis_type}이 완료되었습니다![/green]\n\n"
+            f"[bold]저장 위치:[/bold] {output_path}",
+            title="🎉 분석 완료",
+            border_style="green"
+        )
+        console.print(success_panel)
 
 
 def show_filter_summary(summary: dict, output_path: Path):
@@ -446,7 +466,11 @@ def execute_redundancy_analysis(policy_file: str, vendor: str = "paloalto", outp
             progress.update(task2, description="✅ 중복성 분석 완료")
             
             # 결과 저장
-            final_output_file = output_file or f"redundancy_analysis_{vendor}.xlsx"
+            if not output_file:
+                today = datetime.now().strftime("%Y-%m-%d")
+                final_output_file = f"{today}_redundancy_analysis_{vendor}.xlsx"
+            else:
+                final_output_file = output_file
             output_path = Path(config.get_output_dir()) / final_output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
             
@@ -499,7 +523,11 @@ def execute_shadow_analysis(policy_file: str, vendor: str = "paloalto", output_f
             progress.update(task2, description="✅ Shadow 분석 완료")
             
             # 결과 저장
-            final_output_file = output_file or f"shadow_analysis_{vendor}.xlsx"
+            if not output_file:
+                today = datetime.now().strftime("%Y-%m-%d")
+                final_output_file = f"{today}_shadow_analysis_{vendor}.xlsx"
+            else:
+                final_output_file = output_file
             output_path = Path(config.get_output_dir()) / final_output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
             
@@ -577,8 +605,9 @@ def execute_policy_filter(policy_file: str, search_address: str, search_type: st
             
             # 결과 저장
             if not output_file:
+                today = datetime.now().strftime("%Y-%m-%d")
                 safe_address = search_address.replace('/', '_').replace('-', '_')
-                output_file = f"filtered_policies_{search_type}_{safe_address}.xlsx"
+                output_file = f"{today}_filtered_policies_{search_type}_{safe_address}.xlsx"
             
             output_path = Path(config.get_output_dir()) / output_file
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)

--- a/cli/commands/analyzer.py
+++ b/cli/commands/analyzer.py
@@ -161,14 +161,14 @@ def redundancy(
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
             
             with pd.ExcelWriter(str(output_path), engine='openpyxl') as writer:
-                for sheet_name, data in results.items():
-                    if isinstance(data, pd.DataFrame):
-                        data.to_excel(writer, sheet_name=sheet_name, index=False)
+                results.to_excel(writer, sheet_name="redundancy_rules", index=False)
             
             progress.update(task3, description="✅ 결과 저장 완료")
         
         # 결과 요약 표시
-        show_analysis_summary(results, output_path, "중복성 분석")
+        # results를 딕셔너리 형태로 변환하여 show_analysis_summary에 전달
+        results_dict = {"redundancy_rules": results}
+        show_analysis_summary(results_dict, output_path, "중복성 분석")
         
     except Exception as e:
         logger.error(f"중복성 분석 중 오류 발생: {e}")
@@ -475,14 +475,14 @@ def execute_redundancy_analysis(policy_file: str, vendor: str = "paloalto", outp
             task3 = progress.add_task("결과 Excel 저장 중...", total=None)
             
             with pd.ExcelWriter(str(output_path), engine='openpyxl') as writer:
-                for sheet_name, data in results.items():
-                    if isinstance(data, pd.DataFrame):
-                        data.to_excel(writer, sheet_name=sheet_name, index=False)
+                results.to_excel(writer, sheet_name="redundancy_rules", index=False)
             
             progress.update(task3, description="✅ 결과 저장 완료")
         
         # 결과 요약 표시
-        show_analysis_summary(results, output_path, "중복성 분석")
+        # results를 딕셔너리 형태로 변환하여 show_analysis_summary에 전달
+        results_dict = {"redundancy_rules": results}
+        show_analysis_summary(results_dict, output_path, "중복성 분석")
         return True
         
     except Exception as e:

--- a/fpat/firewall_analyzer/core/redundancy_analyzer.py
+++ b/fpat/firewall_analyzer/core/redundancy_analyzer.py
@@ -137,16 +137,8 @@ class RedundancyAnalyzer:
             # 중복 결과가 없는 경우 처리
             if duplicated_results.empty:
                 self.logger.info("중복 정책이 발견되지 않았습니다.")
-                # 분석 결과가 없음을 나타내는 딕셔너리 반환
-                return {
-                    'redundancy_rules': pd.DataFrame(columns=['No', 'Type'] + list(df.columns)),
-                    'summary': pd.DataFrame([{
-                        'total_policies': len(df_filtered),
-                        'duplicate_policies': 0,
-                        'duplicate_groups': 0,
-                        'message': '중복 정책이 발견되지 않았습니다.'
-                    }])
-                }
+                # 빈 DataFrame 반환 (기존 호환성 유지)
+                return pd.DataFrame(columns=['No', 'Type'] + list(df.columns))
             
             # No 재부여
             duplicated_results['No'] = duplicated_results.groupby('No').ngroup() + 1
@@ -159,17 +151,7 @@ class RedundancyAnalyzer:
             duplicated_results = duplicated_results.sort_values(by=['No', 'Type'], ascending=[True, False])
 
             self.logger.info("중복 정책 분석 완료")
-            
-            # 결과를 딕셔너리 형태로 반환
-            return {
-                'redundancy_rules': duplicated_results,
-                'summary': pd.DataFrame([{
-                    'total_policies': len(df_filtered),
-                    'duplicate_policies': len(duplicated_results),
-                    'duplicate_groups': duplicated_results['No'].nunique(),
-                    'message': f'{duplicated_results["No"].nunique()}개의 중복 그룹이 발견되었습니다.'
-                }])
-            }
+            return duplicated_results
             
         except Exception as e:
             self.logger.error(f"중복 정책 분석 중 오류 발생: {e}")


### PR DESCRIPTION
Add date prefix to CLI output filenames and improve handling of empty analysis results to prevent errors and enhance user feedback.

The `redundancy_analyzer.py` previously encountered errors when no 'Lower' policies were found, leading to an empty `valid_no_groups` list and subsequent `pd.concat` failure. This PR modifies `ensure_upper_and_lower` to return an empty DataFrame in such scenarios, preventing the error and ensuring the `analyze` method consistently returns a DataFrame, maintaining API compatibility. Additionally, the CLI now explicitly informs the user when no analysis results are found.