### PR TITLE
Enable outputs as default download path

### DIFF
--- a/CLI_USAGE.md
+++ b/CLI_USAGE.md
@@ -165,18 +165,20 @@ python fpat_cli.py deletion analyze \
 
 ## 📁 출력 파일
 
-모든 결과는 Excel 파일로 저장되며, 기본 출력 디렉토리는 `./outputs`입니다.
+모든 결과는 Excel 파일로 저장되며, 기본 출력 디렉토리는 현재 디렉토리(`.`)입니다.
 
 ### 출력 디렉토리 변경
 설정 파일 `~/.fpat_config.json`을 편집하여 출력 디렉토리를 변경할 수 있습니다:
 
 ```json
 {
-  "output_dir": "/path/to/custom/output",
+  "output_dir": "./outputs",
   "log_level": "INFO",
   "excel_format": "xlsx"
 }
 ```
+
+위 설정을 사용하면 이전처럼 `outputs` 디렉토리에 결과가 저장됩니다.
 
 ## 🎨 고급 기능
 

--- a/cli/utils/config.py
+++ b/cli/utils/config.py
@@ -19,7 +19,7 @@ class FirewallConfig(BaseModel):
 
 class CLIConfig(BaseModel):
     """CLI 설정"""
-    output_dir: str = "./outputs"
+    output_dir: str = "."  # 기본값을 현재 디렉터리로 변경
     log_level: str = "INFO"
     excel_format: str = "xlsx"
     firewalls: Dict[str, FirewallConfig] = {}
@@ -60,7 +60,11 @@ class Config:
     def get_output_dir(self) -> str:
         """출력 디렉토리를 반환합니다."""
         output_dir = self.config.output_dir
-        os.makedirs(output_dir, exist_ok=True)
+        
+        # 출력 디렉토리가 현재 디렉터리가 아닌 경우에만 생성
+        if output_dir != ".":
+            os.makedirs(output_dir, exist_ok=True)
+        
         return output_dir
     
     def add_firewall(self, name: str, config: FirewallConfig):


### PR DESCRIPTION
Change CLI default output directory to current directory for immediate usability.

The previous default output directory (`./outputs`) for CLI results required users to navigate to a subdirectory to access their generated files. This change makes results directly available in the current working directory, streamlining the workflow.